### PR TITLE
Remove implicit object lifetime cast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,11 +791,11 @@ macro_rules! as_dyn_chronology {
 ///the original `PointerDereferencer`. Unfortunately `T` currently must be `Sized` due to language
 ///limitations.
 impl<T> PointerDereferencer<*mut T> {
-    as_dyn_updatable!(*mut dyn Updatable<E>);
-    as_dyn_getter!(*mut dyn Getter<U, E>);
-    as_dyn_settable!(*mut dyn Settable<U, E>);
-    as_dyn_time_getter!(*mut dyn TimeGetter<E>);
-    as_dyn_chronology!(*mut dyn Chronology<U>);
+    as_dyn_updatable!(*mut (dyn Updatable<E> + '_));
+    as_dyn_getter!(*mut (dyn Getter<U, E> + '_));
+    as_dyn_settable!(*mut (dyn Settable<U, E> + '_));
+    as_dyn_time_getter!(*mut (dyn TimeGetter<E> + '_));
+    as_dyn_chronology!(*mut (dyn Chronology<U> + '_));
 }
 ///These functions get a `PointerDereferencer<*const RwLock<dyn Trait>>` from a
 ///`PointerDereferencer<*const RwLock<T>>` where `T: Trait`. Because raw pointers are `Copy`, they
@@ -803,10 +803,10 @@ impl<T> PointerDereferencer<*mut T> {
 ///currently must be `Sized` due to language limitations.
 #[cfg(feature = "std")]
 impl<T> PointerDereferencer<*const RwLock<T>> {
-    as_dyn_updatable!(*const RwLock<dyn Updatable<E>>);
-    as_dyn_getter!(*const RwLock<dyn Getter<U, E>>);
-    as_dyn_settable!(*const RwLock<dyn Settable<U, E>>);
-    as_dyn_time_getter!(*const RwLock<dyn TimeGetter<E>>);
+    as_dyn_updatable!(*const RwLock<dyn Updatable<E> + '_>);
+    as_dyn_getter!(*const RwLock<dyn Getter<U, E> + '_>);
+    as_dyn_settable!(*const RwLock<dyn Settable<U, E> + '_>);
+    as_dyn_time_getter!(*const RwLock<dyn TimeGetter<E> + '_>);
 }
 ///These functions get a `PointerDereferencer<*const Mutex<dyn Trait>>` from a
 ///`PointerDereferencer<*const Mutex<T>>` where `T: Trait`. Because raw pointers are `Copy`, they
@@ -814,16 +814,16 @@ impl<T> PointerDereferencer<*const RwLock<T>> {
 ///currently must be `Sized` due to language limitations.
 #[cfg(feature = "std")]
 impl<T> PointerDereferencer<*const Mutex<T>> {
-    as_dyn_updatable!(*const Mutex<dyn Updatable<E>>);
-    as_dyn_getter!(*const Mutex<dyn Getter<U, E>>);
-    as_dyn_settable!(*const Mutex<dyn Settable<U, E>>);
-    as_dyn_time_getter!(*const Mutex<dyn TimeGetter<E>>);
+    as_dyn_updatable!(*const Mutex<dyn Updatable<E> + '_>);
+    as_dyn_getter!(*const Mutex<dyn Getter<U, E> + '_>);
+    as_dyn_settable!(*const Mutex<dyn Settable<U, E> + '_>);
+    as_dyn_time_getter!(*const Mutex<dyn TimeGetter<E> + '_>);
 }
 //There are Chronology impls for RwLock<C> and Mutex<C> where C: Chronology. It is necessary to
 //implement Updatable etc. for *const RwLock<T> and *const Mutex<T> directly rather than doing it
 //more generically like for Chronology because they require mutability.
 impl<T> PointerDereferencer<*const T> {
-    as_dyn_chronology!(*const dyn Chronology<U>);
+    as_dyn_chronology!(*const (dyn Chronology<U> + '_));
 }
 //FIXME: Make one of these work if you can, preferably From since it implies Into.
 /*impl<P> From<PointerDereferencer<P>> for P {


### PR DESCRIPTION
Hi there o/

I'm a member of the Rust Language's Types Team; as part of stabilizing the `arbitrary_self_types` and `derive_coerce_pointee` features we are changing what raw pointer casts are legal (rust-lang/rust#136702). Specifically, casting `*const dyn Trait + 'a` to `*const dyn Trait + 'b` where it is not able to be proven that `'a` outlives `'b` will become an error.

Without going into too much detail, the justification for this change is that casting trait object's lifetime bound to a lifetime that lives for a longer time could invalidate the VTable of the trait object, allowing for dispatching to methods that should not be callable. See this example from the linked issue:
```rust
#![forbid(unsafe_code)]
#![feature(arbitrary_self_types, derive_coerce_pointee)]

use std::any::TypeId;
use std::marker::{CoercePointee, PhantomData};

#[derive(CoercePointee)]
#[repr(transparent)]
struct SelfPtr<T: ?Sized>(*const T);

impl<T: ?Sized> std::ops::Deref for SelfPtr<T> {
    type Target = T;
    fn deref(&self) -> &T {
        panic!("please don't call me, I just want the `Receiver` impl!");
    }
}

trait GetTypeId {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static;
}

impl<T: ?Sized> GetTypeId for PhantomData<T> {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static,
    {
        TypeId::of::<T>()
    }
}

// no `T: 'static` bound necessary
fn type_id_of<T: ?Sized>() -> TypeId {
    let ptr = SelfPtr(
        &PhantomData::<T> as *const (dyn GetTypeId + '_) as *const (dyn GetTypeId + 'static),
    );
    ptr.get_type_id()
}

``` 

Unfortunately, going through the usual "future compatibility warning" process turned out to not be possible as checking lifetime constraints without emitting an error is prohibitively difficult to do in the implementation of the borrow checker. This means that you will never receive an FCW and its associated grace period to update your code to be compatible with the new rules.

I have attempted to update your codebase to the new rules for you so that it will still compile when we make this change. I hope this breakage won't cause you too much trouble and that you might even find the post-migration code to be better than how it was previously :-)

If you have any questions about why this change is required please let me know and I'll do my best to further explain the justification.

---

It wasn't clear to me if the pointer casts here were *supposed* to be implicitly casting the lifetimes of the trait object to `'static`. This is currently happening because writing `*mut dyn Trait` in the return type of a function signature desguars to `*mut dyn Trait + 'static`, with this change we now write `*mut dyn Trait + '_` which introduces a new lifetime parameter.